### PR TITLE
Use cl-lib and other cleanup

### DIFF
--- a/pg.el
+++ b/pg.el
@@ -24,7 +24,7 @@
 
 ;;; Commentary:
 
-;;; Overview ==========================================================
+;;;; Overview =========================================================
 ;;
 ;; This module lets you access the PostgreSQL object-relational DBMS
 ;; from Emacs, using its socket-level frontend/backend protocol. The
@@ -34,7 +34,7 @@
 ;; and up, and XEmacs 20 and up. Performance is very poor when not
 ;; byte-compiled.
 
-;;; Entry points =======================================================
+;;;; Entry points ======================================================
 ;;
 ;; (with-pg-connection con (dbname user [password host port]) &body body)
 ;;     A macro which opens a connection to database DBNAME, executes the
@@ -243,7 +243,7 @@
 ;;    end of the tunnel, since pg.el defaults to this value.
 
 
-;;; INSTALL =========================================================
+;;;; INSTALL ========================================================
 ;;
 ;; Place this file in a directory somewhere in the load-path, then
 ;; byte-compile it (do a `B' on it in dired, for example). Place a

--- a/pg.el
+++ b/pg.el
@@ -519,14 +519,12 @@ a result structure which can be decoded using `pg:result'."
 
                ;; EmptyQueryResponse
                (?I
-                (let ((c (pg:read-char connection)))
-                  ))
+                (pg:read-char connection))
 
                ;; BackendKeyData
                (?K
                 (setf (pgcon-pid connection) (pg:read-net-int connection 4))
                 (setf (pgcon-secret connection) (pg:read-net-int connection 4)))
-
 
                ;; NoticeResponse
                (?N
@@ -881,8 +879,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
          (oid (pg:lo-create connection "rw"))
          (fdout (pg:lo-open connection oid "w"))
          (pos (point-min)))
-    (save-excursion
-      (set-buffer buf)
+    (with-current-buffer buf
       (insert-file-contents-literally filename)
       (while (< pos (point-max))
         (pg:lo-write
@@ -896,8 +893,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 (defun pg:lo-export (connection oid filename)
   (let* ((buf (get-buffer-create (format " *pg-%d" oid)))
          (fdin (pg:lo-open connection oid "r")))
-    (save-excursion
-      (set-buffer buf)
+    (with-current-buffer buf
       (cl-do ((str (pg:lo-read connection fdin 1024)
                    (pg:lo-read connection fdin 1024)))
           ((or (not str)

--- a/pg.el
+++ b/pg.el
@@ -1,29 +1,26 @@
 ;;; pg.el --- Emacs Lisp interface to the PostgreSQL RDBMS
-;;;
-;;; Author: Eric Marsden <emarsden@laas.fr>
-;;; Maintainer: Helmut Eller <heller@common-lisp.net>
-;;; Version: 0.13+ (sorta)
-;;; Keywords: data comm database postgresql
-;;;
-;;; Copyright: (C) 1999-2005  Eric Marsden
-;;; Copyright: (C) 2005-2006  Eric Marsden, Helmut Eller
 ;;
-;;     This program is free software; you can redistribute it and/or
-;;     modify it under the terms of the GNU General Public License as
-;;     published by the Free Software Foundation; either version 2 of
-;;     the License, or (at your option) any later version.
-;;
-;;     This program is distributed in the hope that it will be useful,
-;;     but WITHOUT ANY WARRANTY; without even the implied warranty of
-;;     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-;;     GNU General Public License for more details.
-;;
-;;     You should have received a copy of the GNU General Public
-;;     License along with this program; if not, write to the Free
-;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
-;;     MA 02111-1307, USA.
-;;
+;; Copyright (C) 1999-2006  Eric Marsden
+;; Copyright (C) 2005-2006  Helmut Eller
 
+;; Author: Eric Marsden <emarsden@laas.fr>
+;; Maintainer: Helmut Eller <heller@common-lisp.net>
+;; Version: 0.13+ (sorta)
+;; Keywords: data comm database postgresql
+;; SPDX-License-Identifier: GPL-2.0-or-later
+;;
+;; This file is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 2 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/pg.el
+++ b/pg.el
@@ -224,7 +224,7 @@
 ;;
 ;; 1. Establish a tunnel to the backend machine, like this:
 ;; 
-;; 	ssh -L 3333:backend.dom:5432 postgres@backend.dom
+;;         ssh -L 3333:backend.dom:5432 postgres@backend.dom
 ;; 
 ;;    The first number in the -L argument, 3333, is the port number of
 ;;    your end of the tunnel. The second number, 5432, is the remote
@@ -331,8 +331,8 @@ session (not per connection to the backend).")
 
 (defconst pg:ISODATE_REGEX 
   (concat "\\([0-9]+\\)-\\([0-9][0-9]\\)-\\([0-9][0-9]\\) " ; Y-M-D
-	  "\\([0-9][0-9]\\):\\([0-9][0-9]\\):\\([.0-9]+\\)" ; H:M:S.S
-	  "\\([-+][0-9]+\\)?")) ; TZ
+          "\\([0-9][0-9]\\):\\([0-9][0-9]\\):\\([.0-9]+\\)" ; H:M:S.S
+          "\\([-+][0-9]+\\)?")) ; TZ
 
 ;; alist of (oid . parser) pairs. This is built dynamically at
 ;; initialization of the connection with the database (once generated,
@@ -406,7 +406,7 @@ called 'pg-finished."
 
 (defun* pg:connect (dbname user
                    &optional (password "") (host "localhost") (port 5432)
-		   (encoding 'latin-1))
+                   (encoding 'latin-1))
   "Initiate a connection with the PostgreSQL backend.
 Connect to the database DBNAME with the username USER, on PORT of
 HOST, providing PASSWORD if necessary. Return a connection to the
@@ -431,7 +431,7 @@ database (as an opaque type). PORT defaults to 5432, HOST to
     (pg:flush connection)
     (loop for c = (pg:read-char connection) do
       (cond ((eq ?E c) 
-	     (error "Backend error: %s" (pg:read-string connection 4096)))
+             (error "Backend error: %s" (pg:read-string connection 4096)))
             ((eq ?R c)
              (let ((areq (pg:read-net-int connection 4)))
                (cond
@@ -439,11 +439,11 @@ database (as an opaque type). PORT defaults to 5432, HOST to
                  (and (not pg:disable-type-coercion)
                      (null pg:parsers)
                      (pg:initialize-parsers connection))
-		 (let ((enc (ecase encoding
-			      (latin-1 "LATIN-1")
-			      (utf-8 "UTF-8"))))
-		   (pg:exec connection 
-			    (format "SET client_encoding = '%s';" enc)))
+                 (let ((enc (ecase encoding
+                              (latin-1 "LATIN-1")
+                              (utf-8 "UTF-8"))))
+                   (pg:exec connection 
+                            (format "SET client_encoding = '%s';" enc)))
                  (pg:exec connection "SET datestyle = 'ISO';")
                  (return-from pg:connect connection))
                 ((= areq pg:AUTH_REQ_PASSWORD)
@@ -458,15 +458,15 @@ database (as an opaque type). PORT defaults to 5432, HOST to
                 ((= areq pg:AUTH_REQ_KRB5)
                  (error "Kerberos5 authentication not supported"))
                 ((= areq pg:AUTH_REQ_MD5)
-		 (let* ((salt (pg:read-chars connection 4))
-			(crypted (pg:md5-encode user password salt)))
-		   ;;(message "md5 %S %S %S => %S\n"
-		   ;;	    user password salt crypted)
-		   (pg:send-int connection (+ 5 (length crypted)) 4)
-		   (pg:send connection crypted)
-		   (pg:send-int connection 0 1)
-		   (pg:flush connection)))
-		(t
+                 (let* ((salt (pg:read-chars connection 4))
+                        (crypted (pg:md5-encode user password salt)))
+                   ;;(message "md5 %S %S %S => %S\n"
+                   ;;       user password salt crypted)
+                   (pg:send-int connection (+ 5 (length crypted)) 4)
+                   (pg:send connection crypted)
+                   (pg:send-int connection 0 1)
+                   (pg:flush connection)))
+                (t
                  (error "Can't do that type of authentication: %s" areq)))))
             (t
              (error "Problem connecting: expected an authentication response"))))))
@@ -482,7 +482,7 @@ a result structure which can be decoded using `pg:result'."
     (if (> (length sql) pg:MAX_MESSAGE_LEN)
         (error "SQL statement too long: %s" sql))
     (let ((str (encode-coding-string (format "%c%s%c" ?Q sql 0)
-				     (pgcon-encoding connection))))
+                                     (pgcon-encoding connection))))
       ;;;(debug nil str)
       (pg:send connection str))
     (pg:flush connection)
@@ -534,8 +534,8 @@ a result structure which can be decoded using `pg:result'."
             (?N
              (let ((notice (pg:read-string connection pg:MAX_MESSAGE_LEN)))
                (message "NOTICE: %s" notice)
-	       ;;(debug nil notice)
-	       ))
+               ;;(debug nil notice)
+               ))
 
             ;; CursorResponse
             (?P
@@ -677,14 +677,14 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 (defun pg:isodate-parser (str)
   (if (string-match pg:ISODATE_REGEX str)  ; is non-null
       (let ((year    (string-to-number (match-string 1 str)))
-	    (month   (string-to-number (match-string 2 str)))
-	    (day     (string-to-number (match-string 3 str)))
-	    (hours   (string-to-number (match-string 4 str)))
-	    (minutes (string-to-number (match-string 5 str)))
-	    (seconds (round (string-to-number (match-string 6 str))))
-	    (tzs (when (match-string 7 str)
-		   (* 3600 (string-to-number (match-string 7 str))))))
-	(encode-time seconds minutes hours day month year tzs))
+            (month   (string-to-number (match-string 2 str)))
+            (day     (string-to-number (match-string 3 str)))
+            (hours   (string-to-number (match-string 4 str)))
+            (minutes (string-to-number (match-string 5 str)))
+            (seconds (round (string-to-number (match-string 6 str))))
+            (tzs (when (match-string 7 str)
+                   (* 3600 (string-to-number (match-string 7 str))))))
+        (encode-time seconds minutes hours day month year tzs))
     (error "Badly formed ISO timestamp from backend: %s" str)))
 
 
@@ -720,17 +720,17 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 
 (defun pg:md5-hex-digest (string)
   (cond ((fboundp 'md5) (md5 string))
-	(t
-	 (let ((tmpfile (make-temp-name "/tmp/md5-hex")))
-	   (with-temp-file tmpfile (insert string))
-	   (unwind-protect
-	       (with-temp-buffer
-		 (let ((c (call-process "md5sum" tmpfile (current-buffer))))
-		   (assert (zerop c))
-		   (goto-char (point-min))
-		   (search-forward " ")
-		   (buffer-substring 1 (1- (point)))))
-	     (delete-file tmpfile))))))
+        (t
+         (let ((tmpfile (make-temp-name "/tmp/md5-hex")))
+           (with-temp-file tmpfile (insert string))
+           (unwind-protect
+               (with-temp-buffer
+                 (let ((c (call-process "md5sum" tmpfile (current-buffer))))
+                   (assert (zerop c))
+                   (goto-char (point-min))
+                   (search-forward " ")
+                   (buffer-substring 1 (1- (point)))))
+             (delete-file tmpfile))))))
 
 ;; large object support ================================================
 ;;
@@ -830,7 +830,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 (defun pg:lo-create (connection &optional args)
   (let* ((modestr (or args "r"))
          (mode (cond ((integerp modestr) modestr)
-		     ((string= "r" modestr) pg:INV_READ)
+                     ((string= "r" modestr) pg:INV_READ)
                      ((string= "w" modestr) pg:INV_WRITE)
                      ((string= "rw" modestr)
                       (logior pg:INV_READ pg:INV_WRITE))
@@ -847,7 +847,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 (defun pg:lo-open (connection oid &optional args)
   (let* ((modestr (or args "r"))
          (mode (cond ((integerp modestr) modestr)
-		     ((string= "r" modestr) pg:INV_READ)
+                     ((string= "r" modestr) pg:INV_READ)
                      ((string= "w" modestr) pg:INV_WRITE)
                      ((string= "rw" modestr)
                       (logior pg:INV_READ pg:INV_WRITE))
@@ -984,7 +984,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
             (t
              (let* ((len (+ (pg:read-net-int connection 4) correction))
                     (raw (pg:read-chars connection (max 0 len)))
-		    (pg::text-encoding (pgcon-encoding connection))
+                    (pg::text-encoding (pgcon-encoding connection))
                     (parsed (pg:parse raw (car type-ids))))
                (push parsed tuples)))))))
 
@@ -994,12 +994,12 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
     (with-current-buffer (process-buffer process)
       (unless (char-after 1)
         (pg::accept-process-output process 0.001)
-	(while (not (char-after 1))
-	  (pg::accept-process-output process 0.1)))
+        (while (not (char-after 1))
+          (pg::accept-process-output process 0.1)))
       (prog1 (char-after 1)
-	;;(message "read-char: %d %d => %c" 
-	;;	 (point) (buffer-size) (char-after 1))
-	(delete-region 1 2)))))
+        ;;(message "read-char: %d %d => %c" 
+        ;;       (point) (buffer-size) (char-after 1))
+        (delete-region 1 2)))))
 
 ;; FIXME should be more careful here; the integer could overflow.
 (defun pg:read-net-int (connection bytes)
@@ -1020,10 +1020,10 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
     (with-current-buffer (process-buffer process)
       (when (< (buffer-size) howmany)
         (pg::accept-process-output process 0.002)
-	(while (< (buffer-size) howmany)
-	  (pg::accept-process-output process 0.2)))
+        (while (< (buffer-size) howmany)
+          (pg::accept-process-output process 0.2)))
       (prog1 (buffer-substring-no-properties 1 (1+ howmany))
-	(delete-region 1 (1+ howmany))))))
+        (delete-region 1 (1+ howmany))))))
 
 (defvar pg::accept-process-output-supports-floats 
   (ignore-errors (accept-process-output nil 0.0) t))
@@ -1036,13 +1036,13 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
     (error "pg::accept-process-output called recursively"))
   (let ((pg::inside-accept-process-output t))
     (cond (pg::accept-process-output-supports-floats
-	   (accept-process-output process timeout nil 1))
-	  (t
-	   (accept-process-output 
-	    process 
-	    (if timeout (truncate timeout))
-	    ;; Emacs21 uses microsecs; Emacs22 millisecs
-	    (if timeout (truncate (* timeout 1000000))))))))
+           (accept-process-output process timeout nil 1))
+          (t
+           (accept-process-output 
+            process 
+            (if timeout (truncate timeout))
+            ;; Emacs21 uses microsecs; Emacs22 millisecs
+            (if timeout (truncate (* timeout 1000000))))))))
 
 (defun pg::process-send (process string)
   "Wrapper aroud process-send-string."
@@ -1073,9 +1073,9 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 
 (defun pg:send (connection str &optional bytes)
   (let ((process (pgcon-process connection))
-	(data (if (and (numberp bytes) (> bytes (length str)))
-		  (concat str (make-string (- bytes (length str)) 0))
-		str)))
+        (data (if (and (numberp bytes) (> bytes (length str)))
+                  (concat str (make-string (- bytes (length str)) 0))
+                str)))
     (pg::process-send process data)))
 
 ;; This (limited) testing code assumes you have a database user
@@ -1218,4 +1218,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 
 (provide 'pg)
 
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
 ;;; pg.el ends here

--- a/pg.el
+++ b/pg.el
@@ -7,17 +7,17 @@
 ;;;
 ;;; Copyright: (C) 1999-2005  Eric Marsden
 ;;; Copyright: (C) 2005-2006  Eric Marsden, Helmut Eller
-;;   
+;;
 ;;     This program is free software; you can redistribute it and/or
 ;;     modify it under the terms of the GNU General Public License as
 ;;     published by the Free Software Foundation; either version 2 of
 ;;     the License, or (at your option) any later version.
-;;     
+;;
 ;;     This program is distributed in the hope that it will be useful,
 ;;     but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;;     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 ;;     GNU General Public License for more details.
-;;     
+;;
 ;;     You should have received a copy of the GNU General Public
 ;;     License along with this program; if not, write to the Free
 ;;     Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
@@ -154,7 +154,7 @@
 ;;
 ;; (pg:lo-write connection fd buf)
 ;;     Write the bytes contained in the elisp string BUF to the
-;;     large object associated with the file descriptor FD. 
+;;     large object associated with the file descriptor FD.
 ;;
 ;; (pg:lo-lseek conn fd offset whence)
 ;;     Do the equivalent of a lseek(2) on the file descriptor FD which
@@ -223,9 +223,9 @@
 ;; description):
 ;;
 ;; 1. Establish a tunnel to the backend machine, like this:
-;; 
+;;
 ;;         ssh -L 3333:backend.dom:5432 postgres@backend.dom
-;; 
+;;
 ;;    The first number in the -L argument, 3333, is the port number of
 ;;    your end of the tunnel. The second number, 5432, is the remote
 ;;    end of the tunnel -- the port number your backend is using. The
@@ -235,7 +235,7 @@
 ;;    name you are currently logged on as on the client machine. You can
 ;;    use any user name the server machine will accept, not necessarily
 ;;    those related to postgres.
-;; 
+;;
 ;; 2. Now that you have a running ssh session, you can point pg.el to
 ;;    the local host at the port number which you specified in step 1.
 ;;    For example,
@@ -270,7 +270,7 @@
 (eval-and-compile
   (require 'cl))
 
-(defvar pg:disable-type-coercion nil  
+(defvar pg:disable-type-coercion nil
   "*Non-nil disables the type coercion mechanism.
 The default is nil, which means that data recovered from the database
 is coerced to the corresponding Emacs Lisp type before being returned;
@@ -329,7 +329,7 @@ session (not per connection to the backend).")
 ;; "\\([0-9]\\{2\\}\\):\\([0-9]\\{2\\}\\):\\([.0-9]+\\)" ; H:M:S.S
 ;; "\\([-+][0-9]+\\)")) ; TZ
 
-(defconst pg:ISODATE_REGEX 
+(defconst pg:ISODATE_REGEX
   (concat "\\([0-9]+\\)-\\([0-9][0-9]\\)-\\([0-9][0-9]\\) " ; Y-M-D
           "\\([0-9][0-9]\\):\\([0-9][0-9]\\):\\([.0-9]+\\)" ; H:M:S.S
           "\\([-+][0-9]+\\)?")) ; TZ
@@ -397,7 +397,7 @@ called 'pg-finished."
     (catch 'pg-finished
       (with-pg-transaction conn
          (pg:exec conn "DECLARE " cursor " CURSOR FOR " select-form)
-         (unwind-protect 
+         (unwind-protect
              (loop for res = (pg:result (pg:exec conn "FETCH 1 FROM " cursor) :tuples)
                    until (zerop (length res))
                    do (funcall callback res))
@@ -411,7 +411,7 @@ called 'pg-finished."
 Connect to the database DBNAME with the username USER, on PORT of
 HOST, providing PASSWORD if necessary. Return a connection to the
 database (as an opaque type). PORT defaults to 5432, HOST to
-\"localhost\", and PASSWORD to an empty string."  
+\"localhost\", and PASSWORD to an empty string."
   (let* ((buf (generate-new-buffer " *PostgreSQL*"))
          process connection
          (user-packet-length (+ pg:SM_USER pg:SM_OPTIONS pg:SM_UNUSED pg:SM_TTY)))
@@ -430,7 +430,7 @@ database (as an opaque type). PORT defaults to 5432, HOST to
     (pg:send connection user user-packet-length)
     (pg:flush connection)
     (loop for c = (pg:read-char connection) do
-      (cond ((eq ?E c) 
+      (cond ((eq ?E c)
              (error "Backend error: %s" (pg:read-string connection 4096)))
             ((eq ?R c)
              (let ((areq (pg:read-net-int connection 4)))
@@ -442,7 +442,7 @@ database (as an opaque type). PORT defaults to 5432, HOST to
                  (let ((enc (ecase encoding
                               (latin-1 "LATIN-1")
                               (utf-8 "UTF-8"))))
-                   (pg:exec connection 
+                   (pg:exec connection
                             (format "SET client_encoding = '%s';" enc)))
                  (pg:exec connection "SET datestyle = 'ISO';")
                  (return-from pg:connect connection))
@@ -528,8 +528,8 @@ a result structure which can be decoded using `pg:result'."
             (?K
              (setf (pgcon-pid connection) (pg:read-net-int connection 4))
              (setf (pgcon-secret connection) (pg:read-net-int connection 4)))
-             
-            
+
+
             ;; NoticeResponse
             (?N
              (let ((notice (pg:read-string connection pg:MAX_MESSAGE_LEN)))
@@ -549,7 +549,7 @@ a result structure which can be decoded using `pg:result'."
 
             ;; ReadyForQuery
             (?Z t)
-             
+
             (t (error "Unknown response type from backend: %s" c))))))
 
 (defun pg:result (result what &rest arg)
@@ -744,7 +744,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 ;;
 ;; For example, the user can define a new type called "circle", and
 ;; define a C or Tcl function called `circumference' which will act on
-;; circles. There is also an inheritance mechanism in PostgreSQL. 
+;; circles. There is also an inheritance mechanism in PostgreSQL.
 ;;
 ;;======================================================================
 (defvar pg:lo-initialized nil)
@@ -803,7 +803,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 
             ;; FunctionResultResponse
             (?V (setq result t))
-            
+
             ;; Nonempty response
             (?G
              (let* ((len (pg:read-net-int connection 4))
@@ -817,13 +817,13 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
              (let ((notice (pg:read-string connection pg:MAX_MESSAGE_LEN)))
                (message "NOTICE: %s" notice))
              (unix-sync))
-            
+
             ;; ReadyForQuery
             (?Z t)
 
             ;; end of FunctionResult
             (?0 (return result))
-            
+
             (t (error "Unexpected character in pg:fn: ?%c" c))))))
 
 ;; returns an OID
@@ -843,7 +843,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
           (t oid))))
 
 ;; args = modestring (default "r", or "w" or "rw")
-;; returns a file descriptor for use in later pg:lo-* procedures        
+;; returns a file descriptor for use in later pg:lo-* procedures
 (defun pg:lo-open (connection oid &optional args)
   (let* ((modestr (or args "r"))
          (mode (cond ((integerp modestr) modestr)
@@ -865,13 +865,13 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 
 (defsubst pg:lo-write (connection fd buf)
   (pg:fn connection "lowrite" t fd buf))
-  
+
 (defsubst pg:lo-lseek (connection fd offset whence)
   (pg:fn connection "lo_lseek" t fd offset whence))
 
 (defsubst pg:lo-tell (connection oid)
   (pg:fn connection "lo_tell" t oid))
-  
+
 (defsubst pg:lo-unlink (connection oid)
   (pg:fn connection "lo_unlink" t oid))
 
@@ -931,7 +931,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
                       "(relkind = 'r' OR relkind = 'i' OR relkind = 'S') AND "
                       "relname !~ '^pg_' AND usesysid = relowner ORDER BY relname")))
     (apply #'append (pg:result res :tuples))))
-    
+
 (defun pg:columns (conn table)
   "Return a list of the columns present in TABLE."
   (let* ((sql (format "SELECT * FROM %s WHERE 0 = 1" table))
@@ -997,7 +997,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
         (while (not (char-after 1))
           (pg::accept-process-output process 0.1)))
       (prog1 (char-after 1)
-        ;;(message "read-char: %d %d => %c" 
+        ;;(message "read-char: %d %d => %c"
         ;;       (point) (buffer-size) (char-after 1))
         (delete-region 1 2)))))
 
@@ -1025,7 +1025,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
       (prog1 (buffer-substring-no-properties 1 (1+ howmany))
         (delete-region 1 (1+ howmany))))))
 
-(defvar pg::accept-process-output-supports-floats 
+(defvar pg::accept-process-output-supports-floats
   (ignore-errors (accept-process-output nil 0.0) t))
 
 (defvar pg::inside-accept-process-output nil)
@@ -1038,8 +1038,8 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
     (cond (pg::accept-process-output-supports-floats
            (accept-process-output process timeout nil 1))
           (t
-           (accept-process-output 
-            process 
+           (accept-process-output
+            process
             (if timeout (truncate timeout))
             ;; Emacs21 uses microsecs; Emacs22 millisecs
             (if timeout (truncate (* timeout 1000000))))))))
@@ -1048,7 +1048,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
   "Wrapper aroud process-send-string."
   (assert (not pg::inside-accept-process-output))
   (process-send-string process string))
-  
+
 ;; read a null-terminated string
 (defun pg:read-string (connection maxbytes)
   (loop for i from 1 to maxbytes
@@ -1066,7 +1066,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
       (setq num (floor num 256))
       (decf i))
     (pg::process-send process str)))
-  
+
 (defun pg:send-char (connection char)
   (let ((process (pgcon-process connection)))
     (pg::process-send process (char-to-string char))))
@@ -1087,7 +1087,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 ;;
 ;; This code has been tested with GNU Emacs 19.34, 20.3 and 20.6, and
 ;; XEmacs 20.4, on Solaris and linuxppc. It should work with
-;; PostgreSQL 6.x, 7.0, 7.1.2. 
+;; PostgreSQL 6.x, 7.0, 7.1.2.
 
 ;; (defmacro with-pgtest-connection (&rest body)
 ;;   `(with-pg-connection conn ("template1" "postgres")
@@ -1107,12 +1107,12 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 ;;    (pg:test-date)
 ;;    (message "Testing field extraction routines...")
 ;;    (pg:test-result)
-;;    (message "Testing large-object routines...")   
+;;    (message "Testing large-object routines...")
 ;;    (pg:test-lo-read)
 ;;    (pg:test-lo-import)
 ;;    (pg:exec conn "DROP DATABASE pgeltest")
 ;;    (message "Tests passed ok")))
-;; 
+;;
 ;; ;; this will be *real* slow unless byte-compiled
 ;; (defun pg:test-insert ()
 ;;   (with-pgtest-connection
@@ -1127,7 +1127,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 ;;      (setq res (pg:exec conn "SELECT sum(key) FROM count_test"))
 ;;      (assert (= 5050 (first (pg:result res :tuple 0))))
 ;;      (pg:exec conn "DROP TABLE count_test"))))
-;; 
+;;
 ;; ;; Testing for the time handling routines. Expected output is
 ;; ;; something like (in buffer *Messages*)
 ;; ;;
@@ -1146,7 +1146,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 ;;      (message "abstime = %s" (second res))
 ;;      (message "time = %s" (third res)))
 ;;    (pg:exec conn "DROP TABLE date_test")))
-;;   
+;;
 ;; ;; Testing for the data access functions. Expected output is something
 ;; ;; like
 ;; ;;
@@ -1177,10 +1177,10 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 ;;      (message "second tuple of SELECT is %s" (pg:result r4 :tuple 1))
 ;;      (message "status of DROP is %s" (pg:result r5 :status))
 ;;      (message "=============================================="))))
-;; 
+;;
 ;; ;; test of large-object interface. Note the use of with-pg-transaction
 ;; ;; to wrap the requests in a BEGIN..END transaction which is necessary
-;; ;; when working with large objects. 
+;; ;; when working with large objects.
 ;; (defun pg:test-lo-read ()
 ;;   (with-pgtest-connection
 ;;    (with-pg-transaction conn
@@ -1195,7 +1195,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 ;;       (message "==================================================")
 ;;       (pg:lo-close conn fd)
 ;;       (pg:lo-unlink conn oid)))))
-;;   
+;;
 ;; (defun pg:test-lo-import ()
 ;;   (with-pgtest-connection
 ;;    (with-pg-transaction conn
@@ -1208,7 +1208,7 @@ PostgreSQL and Emacs. CONNECTION should no longer be used."
 ;;              (message "lo-import test failed: check differences")
 ;;              (message "between files /etc/group and /tmp/group")))
 ;;       (pg:lo-unlink conn oid)))))
-;; 
+;;
 ;; (defun pg:cleanup ()
 ;;   (interactive)
 ;;   (loop for b in (buffer-list) do


### PR DESCRIPTION
I am the new maintainer of [emacsql](https://github.com/magit/emacsql).

One of its backends uses `pg.el`.  When compiling `emacsql` I get warnings about `cl` being obsolete, even though its `pg` not `emacsql` itself that is still uses this obsolete library.  `cl-lib` is basically the same as `cl`, but symbol names are prefixed with `cl-`.

The main change in this pull-request is the switch `cl-lib`.  I have also cleaned up whitespace and the header.